### PR TITLE
IP method categorizing resolution function by track p_T

### DIFF
--- a/PWGJE/Core/JetTaggingUtilities.h
+++ b/PWGJE/Core/JetTaggingUtilities.h
@@ -653,7 +653,7 @@ float getJetProbability(std::vector<std::unique_ptr<T>> const& fResoFuncjets, U 
       continue;
 
     float probTrack = -1;
-    // jtrack.pt() 범위에 따라 적절한 fResoFuncjet 선택
+    // choose the proper resolution function for the track based on its pt.
     if (track.pt() >= 0.0 && track.pt() < 0.5) {
       probTrack = getTrackProbability(fResoFuncjets.at(0), track, minSignImpXYSig);
     } else if (track.pt() >= 0.5 && track.pt() < 1.0) {

--- a/PWGJE/Core/JetTaggingUtilities.h
+++ b/PWGJE/Core/JetTaggingUtilities.h
@@ -641,6 +641,55 @@ float getJetProbability(T const& fResoFuncjet, U const& jet, V const& /*tracks*/
   return jetProb;
 }
 
+// overloading for the case of using resolution function for each pt range
+template <typename T, typename U, typename V>
+float getJetProbability(std::vector<std::unique_ptr<T>> const& fResoFuncjets, U const& jet, V const& /*tracks*/, float trackDcaXYMax, float trackDcaZMax, float minSignImpXYSig = -10)
+{
+  std::vector<float> jetTracksPt;
+  float trackjetProb = 1.;
+
+  for (auto const& track : jet.template tracks_as<V>()) {
+    if (!trackAcceptanceWithDca(track, trackDcaXYMax, trackDcaZMax))
+      continue;
+
+    float probTrack = -1;
+    // jtrack.pt() 범위에 따라 적절한 fResoFuncjet 선택
+    if (track.pt() >= 0.0 && track.pt() < 0.5) {
+      probTrack = getTrackProbability(fResoFuncjets.at(0), track, minSignImpXYSig);
+    } else if (track.pt() >= 0.5 && track.pt() < 1.0) {
+      probTrack = getTrackProbability(fResoFuncjets.at(1), track, minSignImpXYSig);
+    } else if (track.pt() >= 1.0 && track.pt() < 2.0) {
+      probTrack = getTrackProbability(fResoFuncjets.at(2), track, minSignImpXYSig);
+    } else if (track.pt() >= 2.0 && track.pt() < 4.0) {
+      probTrack = getTrackProbability(fResoFuncjets.at(3), track, minSignImpXYSig);
+    } else if (track.pt() >= 4.0 && track.pt() < 6.0) {
+      probTrack = getTrackProbability(fResoFuncjets.at(4), track, minSignImpXYSig);
+    } else if (track.pt() >= 6.0 && track.pt() < 9.0) {
+      probTrack = getTrackProbability(fResoFuncjets.at(5), track, minSignImpXYSig);
+    } else if (track.pt() >= 9.0) {
+      probTrack = getTrackProbability(fResoFuncjets.at(6), track, minSignImpXYSig);
+    }
+
+    auto geoSign = getGeoSign(jet, track);
+    if (geoSign > 0) { // only take positive sign track for JP calculation
+      trackjetProb *= probTrack;
+      jetTracksPt.push_back(track.pt());
+    }
+  }
+
+  float jetProb = -1.;
+  if (jetTracksPt.size() < 2)
+    return -1;
+
+  float sumjetProb = 0.;
+  for (std::vector<float>::size_type i = 0; i < jetTracksPt.size(); i++) {
+    sumjetProb += (std::pow(-1 * std::log(trackjetProb), static_cast<int>(i)) / TMath::Factorial(i));
+  }
+
+  jetProb = trackjetProb * sumjetProb;
+  return jetProb;
+}
+
 // For secaondy vertex method utilites
 template <typename ProngType, typename JetType>
 typename ProngType::iterator jetFromProngMaxDecayLength(const JetType& jet, float const& prongChi2PCAMin, float prongChi2PCAMax, float prongsigmaLxyMax, float prongIPxyMin, float prongIPxyMax, bool doXYZ = false, bool* checkSv = nullptr)

--- a/PWGJE/TableProducer/jetTaggerHF.cxx
+++ b/PWGJE/TableProducer/jetTaggerHF.cxx
@@ -93,6 +93,10 @@ struct JetTaggerHFTask {
   Configurable<int64_t> timestampCCDB{"timestampCCDB", -1, "timestamp of the ONNX file for ML model used to query in CCDB"};
   Configurable<bool> loadModelsFromCCDB{"loadModelsFromCCDB", false, "Flag to enable or disable the loading of models from CCDB"};
 
+  Configurable<std::string> IPparameterPathsCCDB{"IPparameterPathsCCDB", "Users/l/leehy/LHC24g4/", "Paths for fitting parameters of resolution functions for IP method on CCDB"};
+  Configurable<std::vector<int64_t>> IPtimestampCCDB{"IPtimestampCCDB", std::vector<int64_t>{1737027389227, 1737027391774, 1737027393668, 1737027395548, 1737027397505, 1737027399396, 1737027401294}, "timestamp of the resolution function for IP method used to query in CCDB"};
+  Configurable<bool> usepTcategorize{"usepTcategorize", false, "p_T categorize TF1 function with Inclusive jet"};
+
   // axis spec
   ConfigurableAxis binTrackProbability{"binTrackProbability", {100, 0.f, 1.f}, ""};
   ConfigurableAxis binJetFlavour{"binJetFlavour", {6, -0.5, 5.5}, ""};
@@ -105,12 +109,30 @@ struct JetTaggerHFTask {
   bool useResoFuncFromIncJet = false;
   int maxOrder = -1;
   int resoFuncMatch = 0;
-  std::vector<float> jetProb;
+
   std::unique_ptr<TF1> fSignImpXYSigData = nullptr;
   std::unique_ptr<TF1> fSignImpXYSigIncJetMC = nullptr;
   std::unique_ptr<TF1> fSignImpXYSigCharmJetMC = nullptr;
   std::unique_ptr<TF1> fSignImpXYSigBeautyJetMC = nullptr;
   std::unique_ptr<TF1> fSignImpXYSigLfJetMC = nullptr;
+
+  std::vector<float> vecParamsIncJetMC_CCDB_0;
+  std::vector<float> vecParamsIncJetMC_CCDB_1;
+  std::vector<float> vecParamsIncJetMC_CCDB_2;
+  std::vector<float> vecParamsIncJetMC_CCDB_3;
+  std::vector<float> vecParamsIncJetMC_CCDB_4;
+  std::vector<float> vecParamsIncJetMC_CCDB_5;
+  std::vector<float> vecParamsIncJetMC_CCDB_6;
+
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_0 = nullptr;
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_1 = nullptr;
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_2 = nullptr;
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_3 = nullptr;
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_4 = nullptr;
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_5 = nullptr;
+  std::unique_ptr<TF1> fSignImpXYSigIncJetMC_CCDB_6 = nullptr;
+
+  std::vector<std::unique_ptr<TF1>> fSignImpXYSigIncJetMC_CCDB_vec;
 
   std::vector<uint16_t> decisionNonML;
   std::vector<float> scoreML;
@@ -123,7 +145,11 @@ struct JetTaggerHFTask {
       jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigData, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
     } else {
       if (useResoFuncFromIncJet) {
-        jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigIncJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+        if (usepTcategorize) {
+          jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigIncJetMC_CCDB_vec, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+        } else {
+          jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigIncJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
+        }
       } else {
         if (origin == JetTaggingSpecies::charm) {
           jetProb = jettaggingutilities::getJetProbability(fSignImpXYSigCharmJetMC, jet, tracks, trackDcaXYMax, trackDcaZMax, minSignImpXYSig);
@@ -206,6 +232,27 @@ struct JetTaggerHFTask {
     std::vector<float> vecParamsBeautyJetMC;
     std::vector<float> vecParamsLfJetMC;
 
+    TF1* CCDB_ResoFunc_0 = nullptr;
+    TF1* CCDB_ResoFunc_1 = nullptr;
+    TF1* CCDB_ResoFunc_2 = nullptr;
+    TF1* CCDB_ResoFunc_3 = nullptr;
+    TF1* CCDB_ResoFunc_4 = nullptr;
+    TF1* CCDB_ResoFunc_5 = nullptr;
+    TF1* CCDB_ResoFunc_6 = nullptr;
+
+    ccdbApi.init(ccdbUrl);
+    if (usepTcategorize) {
+      std::map<std::string, std::string> metadata; // dummy meta data (will be updated)
+      // fill the timestamp directly of each TF1 according to p_T track range
+      CCDB_ResoFunc_0 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(0)); // 0 < p_T < 0.5
+      CCDB_ResoFunc_1 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(1)); // 0.5 < p_T < 1
+      CCDB_ResoFunc_2 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(2)); // 1 < p_T < 2
+      CCDB_ResoFunc_3 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(3)); // 2 < p_T < 4
+      CCDB_ResoFunc_4 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(4)); // 4 < p_T < 6
+      CCDB_ResoFunc_5 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(5)); // 6 < p_T < 9
+      CCDB_ResoFunc_6 = ccdbApi.retrieveFromTFileAny<TF1>(IPparameterPathsCCDB, metadata, IPtimestampCCDB->at(6)); // 9 < p_T
+    }
+
     maxOrder = numCount + 1; // 0: untagged, >1 : N ordering
 
     // Set up the resolution function
@@ -250,6 +297,19 @@ struct JetTaggerHFTask {
         LOG(info) << "defined parameters of resolution function: PYTHIA8, JJ, weighted, LHC24g4 & use inclusive distribution";
         useResoFuncFromIncJet = true;
         break;
+      case 6: // TODO
+        vecParamsData = (std::vector<float>)paramsResoFuncData;
+        for (int i = 0; i < 9; i++) {
+          vecParamsIncJetMC_CCDB_0.emplace_back(CCDB_ResoFunc_0->GetParameter(i));
+          vecParamsIncJetMC_CCDB_1.emplace_back(CCDB_ResoFunc_1->GetParameter(i));
+          vecParamsIncJetMC_CCDB_2.emplace_back(CCDB_ResoFunc_2->GetParameter(i));
+          vecParamsIncJetMC_CCDB_3.emplace_back(CCDB_ResoFunc_3->GetParameter(i));
+          vecParamsIncJetMC_CCDB_4.emplace_back(CCDB_ResoFunc_4->GetParameter(i));
+          vecParamsIncJetMC_CCDB_5.emplace_back(CCDB_ResoFunc_5->GetParameter(i));
+          vecParamsIncJetMC_CCDB_6.emplace_back(CCDB_ResoFunc_6->GetParameter(i));
+        }
+        LOG(info) << "defined parameters of resolution function from CCDB";
+        useResoFuncFromIncJet = true;
       default:
         LOG(fatal) << "undefined parameters of resolution function. Fix it!";
         break;
@@ -260,6 +320,22 @@ struct JetTaggerHFTask {
     fSignImpXYSigCharmJetMC = jettaggingutilities::setResolutionFunction(vecParamsCharmJetMC);
     fSignImpXYSigBeautyJetMC = jettaggingutilities::setResolutionFunction(vecParamsBeautyJetMC);
     fSignImpXYSigLfJetMC = jettaggingutilities::setResolutionFunction(vecParamsLfJetMC);
+
+    fSignImpXYSigIncJetMC_CCDB_0 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_0);
+    fSignImpXYSigIncJetMC_CCDB_1 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_1);
+    fSignImpXYSigIncJetMC_CCDB_2 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_2);
+    fSignImpXYSigIncJetMC_CCDB_3 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_3);
+    fSignImpXYSigIncJetMC_CCDB_4 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_4);
+    fSignImpXYSigIncJetMC_CCDB_5 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_5);
+    fSignImpXYSigIncJetMC_CCDB_6 = jettaggingutilities::setResolutionFunction(vecParamsIncJetMC_CCDB_6);
+
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_0));
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_1));
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_2));
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_3));
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_4));
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_5));
+    fSignImpXYSigIncJetMC_CCDB_vec.emplace_back(std::move(fSignImpXYSigIncJetMC_CCDB_6));
 
     // Use QA for effectivness of track probability
     if (trackProbQA) {


### PR DESCRIPTION
    jetTaggerHF.cxx :
    - Added support for the 24g4 dataset in CCDB.
    - Enabled loading of resolution function parameters from CCDB.

    JetTaggingUtilities.h :
    - Modified to allow overloading of the getJetProbability function.
    - Adjusted to apply different resolution functions based on the track p_T range.